### PR TITLE
removed SCHEDULED_MESSAGES_CHANNEL_ID in setup.py

### DIFF
--- a/lacus/setup.py
+++ b/lacus/setup.py
@@ -30,7 +30,6 @@ class LacusConfig:
         self.BOT_PREFIX = os.environ.get("BOT_PREFIX")
         self.GUILD_ID = int(os.environ.get("GUILD_ID"))
         self.ROLE_ON_JOIN_ID = int(os.environ.get("ROLE_ON_JOIN_ID"))
-        self.SCHEDULED_MESSAGES_CHANNEL_ID = int(os.environ.get("PROMPTS_CHANNEL_ID"))
 
         self.INTENTS = discord.Intents.default()
         self.INTENTS.members = True


### PR DESCRIPTION
# Description
- PROMPTS_CHANNEL_ID was already removed in .env.empty
- scheduled_messages commands are working without this line
closes #26 
